### PR TITLE
Fix tokenizer for dot in identifiers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,7 @@ void tokenize(const char* input) {
             p++;
             token_start = p;
         } else if (isalpha(*p) || *p == '_') {
-            while (isalnum(*p) || *p == '_') p++;
+            while (isalnum(*p) || *p == '_' || *p == '.') p++;
             int length = p - token_start;
             if (length > MAX_TOKEN_LENGTH - 1) length = MAX_TOKEN_LENGTH - 1;
             strncpy(tokens[token_count].value, token_start, length);


### PR DESCRIPTION
## Summary
- support dotted identifiers in tokenizer
- rebuild and run example scripts

## Testing
- `make clean && make`
- `./u404shell builtin.lua` *(prints built-in function results)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc9e0e788320a948c76ac3777e56