### PR TITLE
Add Python-like interactive CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wextra -std=c99 -Iinclude
-LDFLAGS ?= -lm
+LDFLAGS ?= -lm -lreadline
 
 SRC := $(wildcard src/*.c)
 OBJ := $(SRC:.c=.o)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This will execute the script, printing "File exists" if `test.txt` exists, and "
 ### Building
 You can build the project using the provided `Makefile` or the `build.sh` script.
 
+Both methods require the `readline` development libraries to be
+available on your system.
+
 Using make:
 ```sh
 make
@@ -66,6 +69,10 @@ If you used `build.sh`, the executable is placed in the `build` directory:
 ./build/u404shell
 ```
 To execute a script: `./build/u404shell script.txt`
+
+Running the executable with no arguments starts an interactive
+Readline-enabled shell.  The interface provides command history and
+editing much like the Python CLI.  Type `exit` to quit the REPL.
 
 ### Bytecode Compilation
 You can compile a script to bytecode and run that bytecode later.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 CC=${CC:-gcc}
 CFLAGS="-Wall -Wextra -std=c99"
-LDFLAGS="-lm"
+LDFLAGS="-lm -lreadline"
 case "$(uname)" in
   Darwin*)
     CC=${CC:-clang}

--- a/include/shell.h
+++ b/include/shell.h
@@ -61,7 +61,7 @@ typedef struct {
     char name[MAX_TOKEN_LENGTH];
     int start_index;
     int end_index;
-} Function;
+} ShellFunction;
 
 /* Global variables declared in main.c */
 extern Token tokens[MAX_TOKENS];
@@ -71,7 +71,7 @@ extern int current_token;
 extern VariableEntry variables[MAX_VARIABLES];
 extern int variable_count;
 
-extern Function functions[MAX_FUNCTIONS];
+extern ShellFunction functions[MAX_FUNCTIONS];
 extern int function_count;
 
 extern Variable stack[MAX_STACK_SIZE];

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <math.h>
 #include <time.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
 #ifdef _WIN32
     #include <windows.h>
@@ -30,7 +32,7 @@ static char* str_dup(const char* s) {
 VariableEntry variables[MAX_VARIABLES];
 int variable_count = 0;
 
-Function functions[MAX_FUNCTIONS];
+ShellFunction functions[MAX_FUNCTIONS];
 int function_count = 0;
 
 Variable stack[MAX_STACK_SIZE];
@@ -848,23 +850,27 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    char input[1000];
-
     printf("Lua-like Shell\n");
     printf("Type 'exit' to quit\n");
 
     while (1) {
-        printf("> ");
-        if (fgets(input, sizeof(input), stdin) == NULL) {
+        char *line = readline(">>> ");
+        if (!line) {
             break;
         }
 
-        if (strcmp(input, "exit\n") == 0) {
+        if (strcmp(line, "exit") == 0) {
+            free(line);
             break;
         }
 
-        tokenize(input);
-        parse_and_execute();
+        if (*line) {
+            add_history(line);
+            tokenize(line);
+            parse_and_execute();
+        }
+
+        free(line);
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- add readline support and Python-style REPL loop
- rename `Function` struct to `ShellFunction` to avoid readline conflict
- link against readline in build files
- document the interactive shell in README

## Testing
- `make`
- `./build.sh`
- `./u404shell <<'EOF'
print("Hello")
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6848cdeeb87483208e9aff23ef1f81c2