### PR TITLE
Implement math commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a command-line interface to interact with the file system and perfor
 * System operations: list files and directories, print the current working directory, clear the screen <br>
 * Script execution: execute a sequence of commands from a script file <br>
 * Conditional execution: execute commands based on conditions <br>
-* Math functions: random number generation and square root calculation via `math.sqrt` <br>
+* Math functions: random number generation (`random`) and square root calculation via `math.sqrt` <br>
 ### Commands
 * `select-file <filename>`: Select a file for operations like delete. <br>
 * `delete`: Delete the selected file. <br>
@@ -18,7 +18,10 @@ It provides a command-line interface to interact with the file system and perfor
 * `pwd`: Print the current working directory. <br>
 * `clear`: Clear the screen. <br>
 * `uprint <message>`: Print a Unicode string. <br>
+* `random`: Print a random number. <br>
+* `math.sqrt <number>`: Calculate the square root of a number. <br>
 * `help`: Show available commands. <br>
+* `exit`: Exit the shell. <br>
 ### Scripting
 In the U404-Shell, you can execute a script with conditional statements using the execute_script function. This function reads a script file line by line and executes each command. It also supports conditional execution of commands using `if`, `else`, and `endif` statements.
 

--- a/u404shell/Cargo.toml
+++ b/u404shell/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.8"

--- a/u404shell/src/main.rs
+++ b/u404shell/src/main.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::env;
+use rand::Rng;
 
 struct ShellState {
     selected_file: Option<PathBuf>,
@@ -67,6 +68,19 @@ fn uprint(args: &[&str]) {
     println!("{}", args.join(" "));
 }
 
+fn random_number() {
+    let mut rng = rand::thread_rng();
+    let num: u32 = rng.gen_range(0..=100);
+    println!("{}", num);
+}
+
+fn math_sqrt(arg: &str) {
+    match arg.parse::<f64>() {
+        Ok(n) => println!("{}", n.sqrt()),
+        Err(_) => println!("Invalid number"),
+    }
+}
+
 fn help() {
     println!("Available commands:");
     println!("  select-file <file>");
@@ -77,6 +91,8 @@ fn help() {
     println!("  pwd");
     println!("  clear");
     println!("  uprint <message>");
+    println!("  random");
+    println!("  math.sqrt <number>");
     println!("  execute_script <file>");
     println!("  help");
     println!("  exit");
@@ -118,6 +134,10 @@ fn run_command(line: &str, state: &mut ShellState) -> io::Result<bool> {
         "pwd" => { print_pwd(); }
         "clear" => { clear_screen(); }
         "uprint" => { uprint(&parts[1..]); }
+        "random" => { random_number(); }
+        "math.sqrt" => {
+            if let Some(arg) = parts.get(1) { math_sqrt(arg); } else { println!("Usage: math.sqrt <number>"); }
+        }
         "execute_script" => {
             if let Some(f) = parts.get(1) { run_script(Path::new(f), state)?; } else { println!("Usage: execute_script <file>"); }
         }


### PR DESCRIPTION
## Summary
- implement `random` and `math.sqrt` commands
- add `rand` crate dependency
- document new commands in README

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6848d3bc22788320a92f07fca1ba61f4